### PR TITLE
✨ Make Python enums PEP-435 compatible

### DIFF
--- a/bindings/InterfaceBindings.cpp
+++ b/bindings/InterfaceBindings.cpp
@@ -19,14 +19,14 @@
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
-#include "pybind11/cast.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h" // NOLINT(misc-include-cleaner)
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <pybind11/cast.h>
 #include <pybind11/detail/common.h>
+#include <pybind11/native_enum.h>
+#include <pybind11/stl.h> // NOLINT(misc-include-cleaner)
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -64,12 +64,13 @@ struct StatevectorCPP {
 
 void bindFramework(py::module& m) {
   // Bind the VariableType enum
-  py::enum_<VariableType>(m, "VariableType",
-                          "The type of a classical variable.")
+  py::native_enum<VariableType>(m, "VariableType", "enum.Enum",
+                                "The type of a classical variable.")
       .value("VarBool", VarBool, "A boolean variable.")
       .value("VarInt", VarInt, "An integer variable.")
       .value("VarFloat", VarFloat, "A floating-point variable.")
-      .export_values();
+      .export_values()
+      .finalize();
 
   // Bind the VariableValue union
   py::class_<VariableValue>(m, "VariableValue")
@@ -595,8 +596,8 @@ Returns:
 
 void bindDiagnostics(py::module& m) {
   // Bind the ErrorCauseType enum
-  py::enum_<ErrorCauseType>(m, "ErrorCauseType",
-                            "The type of a potential error cause.")
+  py::native_enum<ErrorCauseType>(m, "ErrorCauseType", "enum.Enum",
+                                  "The type of a potential error cause.")
       .value("Unknown", Unknown, "An unknown error cause.")
       .value("MissingInteraction", MissingInteraction,
              "Indicates that an entanglement error may be caused by a missing "
@@ -604,7 +605,8 @@ void bindDiagnostics(py::module& m) {
       .value("ControlAlwaysZero", ControlAlwaysZero,
              "Indicates that an error may be related to a controlled gate with "
              "a control that is always zero.")
-      .export_values();
+      .export_values()
+      .finalize();
 
   // Bind the ErrorCause struct
   py::class_<ErrorCause>(m, "ErrorCause")

--- a/bindings/InterfaceBindings.cpp
+++ b/bindings/InterfaceBindings.cpp
@@ -26,6 +26,7 @@
 #include <pybind11/cast.h>
 #include <pybind11/detail/common.h>
 #include <pybind11/native_enum.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h> // NOLINT(misc-include-cleaner)
 #include <stdexcept>
 #include <string>

--- a/python/mqt/debugger/pydebugger.pyi
+++ b/python/mqt/debugger/pydebugger.pyi
@@ -22,7 +22,18 @@ class VariableType(enum.Enum):
     VarFloat = 2
     """A floating-point variable."""
 
+class ErrorCauseType(enum.Enum):
+    """Represents the type of a potential error cause."""
+
+    Unknown = 0
+    """An unknown error cause."""
+    MissingInteraction = 1
+    """Indicates that an entanglement error may be caused by a missing interaction."""
+    ControlAlwaysZero = 2
+    """Indicates that an error may be related to a controlled gate with a control that is always zero."""
+
 # Classes
+
 class VariableValue:
     """Represents the value of a classical variable.
 
@@ -400,16 +411,6 @@ class SimulationState:
         Returns:
             str: The compiled code.
         """
-
-class ErrorCauseType(enum.Enum):
-    """Represents the type of a potential error cause."""
-
-    Unknown = 0
-    """An unknown error cause."""
-    MissingInteraction = 1
-    """Indicates that an entanglement error may be caused by a missing interaction."""
-    ControlAlwaysZero = 2
-    """Indicates that an error may be related to a controlled gate with a control that is always zero."""
 
 class ErrorCause:
     """Represents a potential cause of an assertion error."""


### PR DESCRIPTION
## Description

This PR exposes enums to Python via `pybind11`'s new `enum.Enum`-compatible `py::native_enum`.

Related to https://github.com/munich-quantum-toolkit/core/issues/1075

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
