### PR TITLE
🍎 Restore support for x86 macOS systems

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,7 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
+            macos-15-intel,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-14]
+        runs-on: [macos-15-intel, macos-14]
         compiler: [clang]
-        config: [Release, Debug]
+        config: [Release]
+        include:
+          - runs-on: macos-14
+            compiler: clang
+            config: Debug
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -95,7 +99,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2022]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15-intel,
+            macos-14,
+            windows-2022,
+          ]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -132,6 +143,7 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
+            macos-15-intel,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,36 @@
+name: Qiskit Upstream Tests
+on:
+  schedule:
+    # Run every Monday at 00:00 UTC
+    - cron: "0 0 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/upstream.yml"
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  qiskit-upstream-tests:
+    name: 🐍⚛️
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-24.04, macos-14, windows-2022]
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-tests.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      setup-z3: true
+
+  create-issue-on-failure:
+    name: Create issue on failure
+    needs: qiskit-upstream-tests
+    if: ${{ always() }}
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-issue.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
+    with:
+      tests-result: ${{ needs.qiskit-upstream-tests.result }}
+    permissions:
+      contents: read
+      issues: write # Needed to create/update issues

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,6 +130,18 @@ def minimums(session: nox.Session) -> None:
         session.run("uv", "tree", "--frozen", env=env)
 
 
+@nox.session(reuse_venv=True, venv_backend="uv", python=PYTHON_ALL_VERSIONS)
+def qiskit(session: nox.Session) -> None:
+    """Tests against the latest version of Qiskit."""
+    with preserve_lockfile():
+        _run_tests(
+            session,
+            extra_command=["uv", "pip", "install", "qiskit[qasm3-import] @ git+https://github.com/Qiskit/qiskit.git"],
+        )
+        env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+        session.run("uv", "pip", "show", "qiskit", env=env)
+
+
 @nox.session(reuse_venv=True)
 def docs(session: nox.Session) -> None:
     """Build the docs. Use "--non-interactive" to avoid serving. Pass "-b linkcheck" to check links."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,15 +11,17 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import shutil
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import nox
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Generator, Sequence
 
 nox.needs_version = ">=2024.3.2"
 nox.options.default_venv_backend = "uv"
@@ -32,6 +34,17 @@ PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True
+
+
+@contextlib.contextmanager
+def preserve_lockfile() -> Generator[None]:
+    """Preserve the lockfile by moving it to a temporary directory."""
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        shutil.move("uv.lock", f"{temp_dir_name}/uv.lock")
+        try:
+            yield
+        finally:
+            shutil.move(f"{temp_dir_name}/uv.lock", "uv.lock")
 
 
 @nox.session(reuse_venv=True)
@@ -107,25 +120,14 @@ def tests(session: nox.Session) -> None:
 @nox.session(reuse_venv=True, venv_backend="uv", python=PYTHON_ALL_VERSIONS)
 def minimums(session: nox.Session) -> None:
     """Test the minimum versions of dependencies."""
-    _run_tests(
-        session,
-        install_args=["--resolution=lowest-direct"],
-        pytest_run_args=["-Wdefault"],
-    )
-    env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
-    session.run("uv", "tree", "--frozen", env=env)
-    session.run("uv", "lock", "--refresh", env=env)
-
-
-@nox.session(reuse_venv=True, venv_backend="uv", python=PYTHON_ALL_VERSIONS)
-def qiskit(session: nox.Session) -> None:
-    """Tests against the latest version of Qiskit."""
-    _run_tests(
-        session,
-        extra_command=["uv", "pip", "install", "qiskit[qasm3-import] @ git+https://github.com/Qiskit/qiskit.git"],
-    )
-    env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
-    session.run("uv", "pip", "show", "qiskit", env=env)
+    with preserve_lockfile():
+        _run_tests(
+            session,
+            install_args=["--resolution=lowest-direct"],
+            pytest_run_args=["-Wdefault"],
+        )
+        env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+        session.run("uv", "tree", "--frozen", env=env)
 
 
 @nox.session(reuse_venv=True)


### PR DESCRIPTION
## Description

This PR reverts #128, which dropped support for x86 macOS systems. This is because GitHub Actions has introduced a `macos-15-intel` runner, enabling us to test on x86 macOS until August 2027.

Furthermore, this PR improves `nox` sessions that manipulate the lock file to ensure that any potential changes are fully undone.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.