### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ from mqt import debugger
 state = debugger.create_ddsim_simulation_state()
 with open("code.qasm", "r") as f:
     state.load_code(f.read())
-f.run_simulation()
-print(f.get_state_vector_full())
+state.run_simulation()
+print(state.get_state_vector_full())
 ```
 
 **Detailed documentation and examples are available at [ReadTheDocs](https://mqt.readthedocs.io/projects/debugger).**


### PR DESCRIPTION
## Description
In the README, the example provided for quick run produced some errors: 
```
AttributeError: '_io.TextIOWrapper' object has no attribute 'run_simulation'

AttributeError: '_io.TextIOWrapper' object has no attribute 'get_state_vector_full'
```
This is due to loading the code into the state object, but the subsequent methods are incorrectly called on the file object.
This fixes the errors and outputs the expected statevector object.

## Checklist

- [✅] The pull request only contains commits that are focused and relevant to this change.
- [✅] I have added appropriate tests that cover the new/changed functionality.
- [✅] I have updated the documentation to reflect these changes.
- [✅] The changes follow the project's style guidelines and introduce no new warnings.
- [✅] The changes are fully tested and pass the CI checks.
- [✅] I have reviewed my own code changes.
