### PR TITLE
⬆️ Update Eigen3 to version 5.0.1

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -36,19 +36,24 @@ list(APPEND FETCH_PACKAGES mqt-core)
 
 # ---------------------------------------------------------------------------------Fetch Eigen3
 # cmake-format: off
-set(EIGEN_VERSION 3.4.0
+set(EIGEN_VERSION 5.0.1
         CACHE STRING "Eigen3 version")
 # cmake-format: on
 FetchContent_Declare(
   Eigen3
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
   GIT_TAG ${EIGEN_VERSION}
-  GIT_SHALLOW TRUE
-  # null is a non-existent subdirectory in Eigen3's repository, so add_subdirectory() becomes a
-  # no-op. This stops Eigen3's own CMakeLists.txt from running, which is only relevant for its
-  # documentation and tests.
-  SOURCE_SUBDIR null)
+  GIT_SHALLOW TRUE)
 list(APPEND FETCH_PACKAGES Eigen3)
+set(EIGEN_BUILD_TESTING
+    OFF
+    CACHE BOOL "Disable testing for Eigen")
+set(BUILD_TESTING
+    OFF
+    CACHE BOOL "Disable general testing")
+set(EIGEN_BUILD_DOC
+    OFF
+    CACHE BOOL "Disable documentation build for Eigen")
 
 if(BUILD_MQT_DEBUGGER_TESTS)
   set(gtest_force_shared_crt
@@ -64,9 +69,6 @@ endif()
 
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-add_library(Eigen3::Eigen INTERFACE IMPORTED)
-set_target_properties(Eigen3::Eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${eigen3_SOURCE_DIR}")
 
 # Hide Eigen3 warnings
 get_target_property(Eigen3_Includes Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
## Description

This PR updates Eigen3 to version 5.0.1. This also allows us to revert https://github.com/munich-quantum-toolkit/debugger/pull/370/commits/437d5b360cee5ddbb5dfeade31cd90a798d4c5e8.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
