### PR TITLE
📌 Pin `scikit-build-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 requires = [
   "nanobind~=2.13.0",
   "setuptools-scm>=9.2.2",
-  "scikit-build-core>=0.12.2",
+  "scikit-build-core~=0.12",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -310,7 +310,7 @@ repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
 build = [
     "nanobind~=2.13.0",
     "setuptools-scm>=9.2.2",
-    "scikit-build-core>=0.12.2",
+    "scikit-build-core~=0.12",
 ]
 test = [
     "pytest>=9.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ provides-extras = ["check"]
 [package.metadata.requires-dev]
 build = [
     { name = "nanobind", specifier = "~=2.13.0" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
@@ -1756,7 +1756,7 @@ dev = [
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "qiskit", specifier = ">=1.2.4" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.15" },
     { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.16.2" },


### PR DESCRIPTION
## Description

This PR pins `scikit-build-core` to `~=0.12` to prevent it from upgrading to version 1.0. The new version is incompatible with `nanobind.stubgen`. Once this issue is resolved, we can upgrade to 1.0 and benefit from the improved system for dynamic metadata. In particular, we should finally be able to drop our dependency on `setuptools-scm`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.