### PR TITLE
♻️ Use the Core OpenQASM serializer

### DIFF
--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -32,7 +32,7 @@
 #include "dd/Package.hpp"
 #include "dd/StateGeneration.hpp"
 #include "ir/Definitions.hpp"
-#include "ir/Register.hpp"
+#include "ir/OpenQASMSerializer.hpp"
 #include "ir/operations/IfElseOperation.hpp"
 #include "ir/operations/OpType.hpp"
 #include "qasm3/Importer.hpp"
@@ -585,9 +585,9 @@ void compileProjectiveMeasurement(
     qubitIndexToRegisterMap.try_emplace(i, reg, originalVariable);
   }
 
+  const qc::OpenQASMSerializer serializer(stream, qc::Format::OpenQASM2);
   for (auto& it : std::ranges::reverse_view(newQc)) {
-    auto inverted = it->getInverted();
-    it->dumpOpenQASM2(stream, qubitIndexToRegisterMap, {});
+    serializer.serialize(*it->getInverted(), qubitIndexToRegisterMap, {});
   }
 
   for (const auto& [qbit, cbit] : targetNames) {
@@ -595,7 +595,7 @@ void compileProjectiveMeasurement(
   }
 
   for (auto& it : newQc) {
-    it->dumpOpenQASM2(stream, qubitIndexToRegisterMap, {});
+    serializer.serialize(*it, qubitIndexToRegisterMap, {});
   }
 }
 

--- a/test/test_compilation_projective_measurements.cpp
+++ b/test/test_compilation_projective_measurements.cpp
@@ -38,10 +38,10 @@ class ProjectiveMeasurementsCompilationTest : public CompilationTest {};
  */
 TEST_F(ProjectiveMeasurementsCompilationTest, ProjectiveSingleOperation) {
   loadCode("qreg q[1];\n"
-           "x q[0];\n"
+           "s q[0];\n"
            "assert-eq q[0] { "
            "qreg p[1];\n"
-           "x p[0];\n"
+           "s p[0];\n"
            "}\n");
 
   PreambleVector preamble;
@@ -49,11 +49,11 @@ TEST_F(ProjectiveMeasurementsCompilationTest, ProjectiveSingleOperation) {
 
   checkCompilation(makeSettings(/*opt=*/0, /*slice=*/0),
                    "qreg q[1];\n"
-                   "x q[0];\n"
+                   "s q[0];\n"
                    "creg test_q0[1];\n"
-                   "x q[0];\n"
+                   "sdg q[0];\n"
                    "measure q[0] -> test_q0[0];\n"
-                   "x q[0];\n",
+                   "s q[0];\n",
                    preamble);
 
   checkNoCompilation(makeSettings(0, 1));


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Migrate projective-assertion compilation to the operation-level serializer
introduced by [MQT Core #2249](https://github.com/munich-quantum-toolkit/core/pull/2249).

- replace the removed `Operation::dumpOpenQASM2` calls with
  `qc::OpenQASMSerializer`;
- reuse one serializer for the forward and inverse assertion circuits;
- serialize the inverted clone that the reverse pass already constructed;
- exercise the non-self-inverse `s`/`sdg` path in the compilation test.

## Draft status

This PR intentionally remains a draft until MQT Core v4 is released. It does
not pin an intermediate Core commit and does not add temporary MLIR/CI setup.
CI is therefore expected to fail against the currently released Core version.

## Dependencies

- Depends on [MQT Core #2249](https://github.com/munich-quantum-toolkit/core/pull/2249)
  and the corresponding MQT Core v4 release.

## Validation

Validated against the Core PR branch before removing the temporary pin:

- focused projective-measurement tests: 6/6
- full Debugger C++ suite: 149/149
- full `uvx nox -s lint`

## AI assistance

Codex materially assisted with implementation, tests, integration validation,
and this pull request description. A human must review and understand the
changes before marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. This waits for MQT Core v4.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
