### PR TITLE
♻️ Migrate circuit flattening to Core v4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${Eigen3_Includes})
 
 # link to the MQT::Core libraries
-target_link_libraries(${PROJECT_NAME} PUBLIC MQT::CoreDD MQT::CoreIR MQT::CoreCircuitOptimizer)
+target_link_libraries(${PROJECT_NAME} PUBLIC MQT::CoreDD MQT::CoreIR)
 target_link_libraries(${PROJECT_NAME} PRIVATE MQT::ProjectWarnings MQT::ProjectOptions
                                               MQT::CoreQASM)
 target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -18,7 +18,6 @@
 #include "backend/dd/DDSimDiagnostics.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "common.h"
 #include "common/ComplexMathematics.hpp"
 #include "common/Span.hpp"
@@ -704,7 +703,7 @@ LoadResult ddsimLoadCode(SimulationState* self, const char* code) {
     std::stringstream ss{preprocessAssertionCode(code, ddsim)};
     const auto imported = qasm3::Importer::import(ss);
     ddsim->qc = std::make_unique<qc::QuantumComputation>(imported);
-    qc::CircuitOptimizer::flattenOperations(*ddsim->qc, true);
+    ddsim->qc->flattenOperations(true);
   } catch (const ParsingError& e) {
     return makeLoadResult(LOAD_PARSE_ERROR, e.line(), e.column(), e.detail());
   } catch (const std::exception& e) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prepare the MQT Debugger for the removal of `qc::CircuitOptimizer` in [MQT Core #2262](https://github.com/munich-quantum-toolkit/core/pull/2262):

- call `QuantumComputation::flattenOperations(true)` directly; and
- remove the obsolete optimizer header and CMake target.

This intentionally leaves the MQT Core version requirement and `uv.lock` unchanged. The PR must remain a draft until Core v4 is released, at which point the dependency pin can be updated and the PR revalidated.

## Stack and dependencies

This is a stacked draft targeting `codex/2098-openqasm-serializer` and depends on [#436](https://github.com/munich-quantum-toolkit/debugger/pull/436), because current Debugger `main` still uses OpenQASM APIs already removed from Core v4. After #436 merges, retarget this PR to `main`. It also depends on Core #2262 and should merge only after the Core v4 release.

## Companion migration drafts

- Core: [munich-quantum-toolkit/core#2262](https://github.com/munich-quantum-toolkit/core/pull/2262)
- QCEC: [munich-quantum-toolkit/qcec#1042](https://github.com/munich-quantum-toolkit/qcec/pull/1042)
- QMAP: [munich-quantum-toolkit/qmap#1125](https://github.com/munich-quantum-toolkit/qmap/pull/1125)
- QuSAT: [munich-quantum-toolkit/qusat#514](https://github.com/munich-quantum-toolkit/qusat/pull/514)
- DDSIM: [munich-quantum-toolkit/ddsim#977](https://github.com/munich-quantum-toolkit/ddsim/pull/977)
- Debugger: [munich-quantum-toolkit/debugger#438](https://github.com/munich-quantum-toolkit/debugger/pull/438)

## Validation

- warning-clean build with `WARNINGS_AS_ERRORS=ON`
- complete 433-target build
- 149/149 full C++ tests
- full `uvx nox -s lint`
- `git diff --check`

## AI assistance

Codex materially assisted with implementation, stacked-branch validation, review, and this pull request description. A human must review and understand the changes before marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable: no public Debugger API changes.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Local Core v4 validation passes; CI requires the future Core v4 pin.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
