### PR TITLE
✨ Support non-equality comparators in classic-controlled if

### DIFF
--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "AssertionParsing.hpp"
+#include "ir/operations/IfElseOperation.hpp"
 
 #include <cstddef>
 #include <map>
@@ -228,6 +229,10 @@ struct ClassicCondition {
    * @brief The expected value in the condition comparison.
    */
   size_t expectedValue;
+  /**
+   * @brief The comparison operator used in the condition.
+   */
+  qc::ComparisonKind kind = qc::Eq;
 };
 
 /**

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -96,6 +96,31 @@ struct DDSimulationStateGuard {
 };
 
 /**
+ * @brief Apply a classical comparison operator between two unsigned values.
+ * @param lhs The left-hand side of the comparison.
+ * @param rhs The right-hand side of the comparison.
+ * @param kind The comparison operator to apply.
+ * @return The boolean result of `lhs <kind> rhs`.
+ */
+bool applyComparison(size_t lhs, size_t rhs, qc::ComparisonKind kind) {
+  switch (kind) {
+  case qc::Eq:
+    return lhs == rhs;
+  case qc::Neq:
+    return lhs != rhs;
+  case qc::Lt:
+    return lhs < rhs;
+  case qc::Leq:
+    return lhs <= rhs;
+  case qc::Gt:
+    return lhs > rhs;
+  case qc::Geq:
+    return lhs >= rhs;
+  }
+  return false;
+}
+
+/**
  * @brief Evaluate a classic-controlled condition from the original code.
  * @param ddsim The simulation state.
  * @param instructionIndex The instruction index to inspect.
@@ -133,7 +158,7 @@ std::optional<bool> evaluateClassicConditionFromCode(DDSimulationState* ddsim,
     }
   }
 
-  return registerValue == parsed->expectedValue;
+  return applyComparison(registerValue, parsed->expectedValue, parsed->kind);
 }
 
 /**
@@ -1104,10 +1129,6 @@ Result ddsimStepForward(SimulationState* self) {
     // register first.
     const auto* op =
         dynamic_cast<qc::IfElseOperation*>((*ddsim->iterator).get());
-    if (op->getComparisonKind() != qc::Eq) {
-      throw std::runtime_error("If-else operations with non-equality "
-                               "comparisons are currently not supported");
-    }
     const auto condition =
         evaluateClassicConditionFromCode(ddsim, currentInstruction);
     bool conditionMet = false;
@@ -1130,7 +1151,8 @@ Result ddsimStepForward(SimulationState* self) {
           registerValue |= (value ? 1ULL : 0ULL) << i;
         }
       }
-      conditionMet = (registerValue == exp);
+      conditionMet =
+          applyComparison(registerValue, exp, op->getComparisonKind());
     }
     if (conditionMet) {
       auto* thenOp = op->getThenOp();
@@ -1202,10 +1224,6 @@ Result ddsimStepBackward(SimulationState* self) {
   if ((*ddsim->iterator)->isIfElseOperation()) {
     const auto* op =
         dynamic_cast<qc::IfElseOperation*>((*ddsim->iterator).get());
-    if (op->getComparisonKind() != qc::Eq) {
-      throw std::runtime_error("If-else operations with non-equality "
-                               "comparisons are currently not supported");
-    }
     const auto condition =
         evaluateClassicConditionFromCode(ddsim, ddsim->currentInstruction);
     bool conditionMet = false;
@@ -1228,7 +1246,8 @@ Result ddsimStepBackward(SimulationState* self) {
           registerValue |= (value ? 1ULL : 0ULL) << i;
         }
       }
-      conditionMet = (registerValue == exp);
+      conditionMet =
+          applyComparison(registerValue, exp, op->getComparisonKind());
     }
     if (conditionMet) {
       auto* thenOp = op->getThenOp();

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -419,7 +419,8 @@ parseClassicConditionExpression(const std::string& condition) {
     std::string_view text;
     qc::ComparisonKind kind;
   };
-  static constexpr std::array<OperatorMatch, 6> OPERATORS{{
+  using OperatorsT = std::array<OperatorMatch, 6>;
+  static constexpr OperatorsT OPERATORS{{
       {.text = "<=", .kind = qc::Leq},
       {.text = ">=", .kind = qc::Geq},
       {.text = "==", .kind = qc::Eq},
@@ -428,16 +429,19 @@ parseClassicConditionExpression(const std::string& condition) {
       {.text = ">", .kind = qc::Gt},
   }};
 
-  const auto* const found =
-      std::ranges::find_if(OPERATORS, [&normalized](const auto& op) {
-        return normalized.find(op.text) != std::string::npos;
-      });
-  if (found == OPERATORS.end()) {
+  std::optional<OperatorMatch> match;
+  for (const auto& op : OPERATORS) {
+    if (normalized.find(op.text) != std::string::npos) {
+      match = op;
+      break;
+    }
+  }
+  if (!match.has_value()) {
     return std::nullopt;
   }
-  const auto opPos = normalized.find(found->text);
+  const auto opPos = normalized.find(match->text);
   const auto lhs = normalized.substr(0, opPos);
-  const auto rhs = normalized.substr(opPos + found->text.size());
+  const auto rhs = normalized.substr(opPos + match->text.size());
   if (lhs.empty() || rhs.empty()) {
     return std::nullopt;
   }
@@ -478,13 +482,13 @@ parseClassicConditionExpression(const std::string& condition) {
     return ClassicCondition{.registerName = base,
                             .bitIndex = bitIndex,
                             .expectedValue = expected,
-                            .kind = found->kind};
+                            .kind = match->kind};
   }
 
   return ClassicCondition{.registerName = lhs,
                           .bitIndex = std::nullopt,
                           .expectedValue = expected,
-                          .kind = found->kind};
+                          .kind = match->kind};
 }
 
 std::optional<ClassicCondition>

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -18,6 +18,7 @@
 #include "common/parsing/AssertionParsing.hpp"
 #include "common/parsing/ParsingError.hpp"
 #include "common/parsing/Utils.hpp"
+#include "ir/operations/IfElseOperation.hpp"
 
 #include <algorithm>
 #include <array>
@@ -418,20 +419,20 @@ parseClassicConditionExpression(const std::string& condition) {
     std::string_view text;
     qc::ComparisonKind kind;
   };
-  static constexpr std::array<OperatorMatch, 6> operators{{
-      {"<=", qc::Leq},
-      {">=", qc::Geq},
-      {"==", qc::Eq},
-      {"!=", qc::Neq},
-      {"<", qc::Lt},
-      {">", qc::Gt},
+  static constexpr std::array<OperatorMatch, 6> OPERATORS{{
+      {.text = "<=", .kind = qc::Leq},
+      {.text = ">=", .kind = qc::Geq},
+      {.text = "==", .kind = qc::Eq},
+      {.text = "!=", .kind = qc::Neq},
+      {.text = "<", .kind = qc::Lt},
+      {.text = ">", .kind = qc::Gt},
   }};
 
-  const auto found =
-      std::ranges::find_if(operators, [&normalized](const auto& op) {
+  const auto* const found =
+      std::ranges::find_if(OPERATORS, [&normalized](const auto& op) {
         return normalized.find(op.text) != std::string::npos;
       });
-  if (found == operators.end()) {
+  if (found == OPERATORS.end()) {
     return std::nullopt;
   }
   const auto opPos = normalized.find(found->text);

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -20,6 +20,7 @@
 #include "common/parsing/Utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstddef>
 #include <exception>
@@ -30,6 +31,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -410,12 +412,31 @@ parseClassicConditionExpression(const std::string& condition) {
   if (!normalized.empty() && normalized.front() == '(') {
     normalized.erase(0, 1);
   }
-  const auto eqPos = normalized.find("==");
-  if (eqPos == std::string::npos) {
+
+  // Operators must be scanned longest-first so that "<=" is not misread as "<".
+  struct OperatorMatch {
+    std::string_view text;
+    qc::ComparisonKind kind;
+  };
+  static constexpr std::array<OperatorMatch, 6> operators{{
+      {"<=", qc::Leq},
+      {">=", qc::Geq},
+      {"==", qc::Eq},
+      {"!=", qc::Neq},
+      {"<", qc::Lt},
+      {">", qc::Gt},
+  }};
+
+  const auto found =
+      std::ranges::find_if(operators, [&normalized](const auto& op) {
+        return normalized.find(op.text) != std::string::npos;
+      });
+  if (found == operators.end()) {
     return std::nullopt;
   }
-  const auto lhs = normalized.substr(0, eqPos);
-  const auto rhs = normalized.substr(eqPos + 2);
+  const auto opPos = normalized.find(found->text);
+  const auto lhs = normalized.substr(0, opPos);
+  const auto rhs = normalized.substr(opPos + found->text.size());
   if (lhs.empty() || rhs.empty()) {
     return std::nullopt;
   }
@@ -453,12 +474,16 @@ parseClassicConditionExpression(const std::string& condition) {
     } catch (const std::out_of_range&) {
       return std::nullopt;
     }
-    return ClassicCondition{
-        .registerName = base, .bitIndex = bitIndex, .expectedValue = expected};
+    return ClassicCondition{.registerName = base,
+                            .bitIndex = bitIndex,
+                            .expectedValue = expected,
+                            .kind = found->kind};
   }
 
-  return ClassicCondition{
-      .registerName = lhs, .bitIndex = std::nullopt, .expectedValue = expected};
+  return ClassicCondition{.registerName = lhs,
+                          .bitIndex = std::nullopt,
+                          .expectedValue = expected,
+                          .kind = found->kind};
 }
 
 std::optional<ClassicCondition>

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -96,6 +96,28 @@ TEST_F(CustomCodeTest, IfElseOperationMulti) {
 }
 
 /**
+ * @test Same behaviour as `IfElseOperationMulti`, but with the `if` body
+ * written as a real multi-line block.
+ * Ensures the parser handles line breaks inside a classic-controlled body,
+ * not only the single-line form.
+ */
+TEST_F(CustomCodeTest, IfElseOperationMultiMultilineBlock) {
+  loadCode(2, 1,
+           "x q[0];\n"
+           "measure q[0] -> c[0];\n"
+           "if(c==1) {\n"
+           "  x q[0];\n"
+           "  x q[1];\n"
+           "}\n");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[2], 1, 0.0));
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -213,6 +213,27 @@ TEST_F(CustomCodeTest, IfElseOperationGeq) {
 }
 
 /**
+ * @test Test classic-controlled operations that condition on a single bit
+ * of a classical register, using a non-equality comparator.
+ * The measured value of `c[0]` is 1, so `c[0] > 0` triggers and
+ * `c[0] > 1` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationSingleBit) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c[0]>0) x q[1];"
+           "if(c[0]>1) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -234,6 +234,32 @@ TEST_F(CustomCodeTest, IfElseOperationSingleBit) {
 }
 
 /**
+ * @test Exercise the backward-execution branch of the DD backend for a
+ * classic-controlled operation with a non-equality comparator.
+ * The measured value of `c` is 1, so `c > 0` triggers and `x q[1]` is
+ * applied on the forward pass; stepping backward undoes that `x q[1]`.
+ */
+TEST_F(CustomCodeTest, IfElseOperationBackwardStep) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c>0) x q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  // q[1] = 0, q[0] = 1  after the `if` fires, so amplitude index 1.
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+
+  ASSERT_EQ(state->stepBackward(state), OK);
+  state->getStateVectorFull(state, &sv);
+  // Undoing the `if`'s `x q[1]` restores q[1] = 1, q[0] = 1, i.e. index 3.
+  ASSERT_TRUE(complexEquality(amplitudes[3], 1, 0.0));
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -118,6 +118,101 @@ TEST_F(CustomCodeTest, IfElseOperationMultiMultilineBlock) {
 }
 
 /**
+ * @test Test classic-controlled operations that use the `!=` comparator.
+ * The measured value of `c` is 1, so `c != 0` triggers and `c != 1` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationNeq) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c!=0) x q[1];"
+           "if(c!=1) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Test classic-controlled operations that use the `<` comparator.
+ * The measured value of `c` is 1, so `c < 2` triggers and `c < 1` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationLt) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c<2) x q[1];"
+           "if(c<1) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Test classic-controlled operations that use the `<=` comparator.
+ * The measured value of `c` is 1, so `c <= 1` triggers and `c <= 0` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationLeq) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c<=1) x q[1];"
+           "if(c<=0) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Test classic-controlled operations that use the `>` comparator.
+ * The measured value of `c` is 1, so `c > 0` triggers and `c > 1` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationGt) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c>0) x q[1];"
+           "if(c>1) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Test classic-controlled operations that use the `>=` comparator.
+ * The measured value of `c` is 1, so `c >= 1` triggers and `c >= 2` does not.
+ */
+TEST_F(CustomCodeTest, IfElseOperationGeq) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c>=1) x q[1];"
+           "if(c>=2) z q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Let the debugger evaluate classic-controlled `if` conditions with any of the six comparison operators supported by `mqt-core`, not just `==`.

### What this PR covers (from #168)

- Non-equality comparators (`!=`, `<`, `<=`, `>`, `>=`) in `if (cond)` conditions.
  Before this PR the DD backend threw at runtime for anything other than `==`, even though `mqt-core`'s `IfElseOperation` already models all six. 
- Regression test for a real multi-line `if { ... }` body.
  The issue suggests this form is not accepted, but it seems it already is; the new test locks that in.

Split into three atomic commits: multi-line body regression test, comparator change with per-operator tests, and a single-bit-condition test on top.

### Not covered here (from or around #168)

- Per-statement stepping inside an `if { ... }` body.
  Today the whole block is a single `Instruction` from the stepper's point of view, so step-over highlights all lines together and breakpoints cannot land inside. This would need `preprocessCode` to expand a classic-controlled block into sub-instructions, similar to how gate bodies are handled.
- Register slicing (`c[a:b]` used as the condition operand).
  I have not explored whether `mqt-core` parses this form or how it would surface in `IfElseOperation`. Single-bit checks like `if (c[0] > 0)` already work as of this PR; see `IfElseOperationSingleBit`.

### Question

Do you prefer that I address these in follow-up PRs, or that I extend this one?

### AI assistance

Commit messages, code changes, and this PR body were drafted with Claude Opus 4.7 via Claude Code.
All content was reviewed and edited manually before submission.

Related to #168.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope,
      as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content and accept full responsibility for it.
