### PR TITLE
⬆️ Require CMake 3.28 and reduce dependency builds

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
+      - uses: munich-quantum-toolkit/templates@26c7cb8534daf355596bf0a31379ba84d097c768 # v1.5.1
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Debugger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@
 - Targets Linux (glibc 2.28+), macOS (11.0+), and Windows on x86_64 and arm64
   architectures
 - C++20
-- CMake 3.24+
+- CMake 3.28+
 - `FetchContent` for dependency management (configured in
   `cmake/ExternalDependencies.cmake`)
 - `clang-format` and `clang-tidy` for formatting/linting (see `.clang-format`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,7 @@
 #
 # Licensed under the MIT License
 
-cmake_minimum_required(VERSION 3.26...4.4)
-cmake_policy(SET CMP0069 NEW)
-set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+cmake_minimum_required(VERSION 3.28...4.4)
 
 project(
   mqt_debugger
@@ -19,6 +17,7 @@ option(BUILD_MQT_DEBUGGER_TESTS "Also build tests for the MQT Debugger project" 
 option(BUILD_MQT_DEBUGGER_APP "Also build the CLI app for the MQT Debugger project" ON)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 include(CheckIPOSupported)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ print(state.get_state_vector_full())
 ## System Requirements
 
 Building the project requires a C++ compiler with support for C++20 and CMake
-3.26 or newer. For details on how to build the project, please refer to the
+3.28 or newer. For details on how to build the project, please refer to the
 [documentation](https://mqt.readthedocs.io/projects/debugger). Building (and
 running) is continuously tested under Linux, macOS, and Windows using the
 [latest available system versions for GitHub Actions](https://github.com/actions/runner-images).

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -31,7 +31,8 @@ set(MQT_CORE_REPO_OWNER "munich-quantum-toolkit"
 FetchContent_Declare(
   mqt-core
   GIT_REPOSITORY https://github.com/${MQT_CORE_REPO_OWNER}/core.git
-  GIT_TAG ${MQT_CORE_REV})
+  GIT_TAG ${MQT_CORE_REV}
+  EXCLUDE_FROM_ALL)
 list(APPEND FETCH_PACKAGES mqt-core)
 
 # ---------------------------------------------------------------------------------Fetch Eigen3
@@ -43,7 +44,8 @@ FetchContent_Declare(
   Eigen3
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
   GIT_TAG ${EIGEN_VERSION}
-  GIT_SHALLOW TRUE)
+  GIT_SHALLOW TRUE
+  SYSTEM)
 list(APPEND FETCH_PACKAGES Eigen3)
 set(EIGEN_BUILD_TESTING
     OFF
@@ -69,6 +71,3 @@ endif()
 
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-# Hide Eigen3 warnings
-get_target_property(Eigen3_Includes Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -193,7 +193,7 @@ instructions on how to set up your development environment.
 
 Building the project requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer. As of August 2025, our CI
+and [CMake](https://cmake.org/) 3.28 or newer. As of August 2025, our CI
 pipeline on GitHub continuously tests the library across the following matrix of
 systems and compilers:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -107,7 +107,7 @@ pip install mqt.debugger --no-binary mqt.debugger
 
 This requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer.
+and [CMake](https://cmake.org/) 3.28 or newer.
 
 ## Integrating MQT Debugger into Your Project
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,13 +21,12 @@ add_library(
 # set include directories
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include
                                                   ${PROJECT_BINARY_DIR}/include)
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${Eigen3_Includes})
 
 # link to the MQT::Core libraries
 target_link_libraries(${PROJECT_NAME} PUBLIC MQT::CoreDD MQT::CoreIR)
 target_link_libraries(${PROJECT_NAME} PRIVATE MQT::ProjectWarnings MQT::ProjectOptions
                                               MQT::CoreQASM)
-target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 
 # add MQT alias
 add_library(MQT::Debugger ALIAS ${PROJECT_NAME})


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Raise the minimum CMake version to 3.28, disable unused C++ module scanning, and use native `FetchContent` `EXCLUDE_FROM_ALL`/`SYSTEM` support for Core and Eigen. Remove obsolete CMP0069 overrides and manual Eigen warning suppression while preserving Eigen's public usage requirement. Pin the templating workflow to Templates v1.5.1.

Prepared with GPT-5/Codex assistance under explicit maintainer authorization.

### Validation

- `uvx nox -s lint`
- Release configure/build and all 149 tests with CMake 4.4.2 and exactly 3.28.4
- Confirmed CMake 3.27 rejects configuration

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.