### PR TITLE
✨ Support `if (c)` and `if (c[k])` as boolean-only conditions

### DIFF
--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -487,6 +487,15 @@ parseClassicConditionExpression(const std::string& condition) {
     }
   }
   if (!match.has_value()) {
+    // Bare register (`c`) or bit (`c[k]`).
+    // Treat it as an implicit `!= 0` check so the existing evaluator handles it
+    // unchanged.
+    if (const auto ref = parseBitRegisterRef(normalized); ref.has_value()) {
+      return ClassicCondition{.registerName = ref->name,
+                              .bitIndex = ref->bitIndex,
+                              .expectedValue = 0,
+                              .kind = qc::Neq};
+    }
     return std::nullopt;
   }
   const auto opPos = normalized.find(match->text);

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -114,7 +114,7 @@ std::optional<BitRegisterRef> parseBitRegisterRef(const std::string& text) {
   const auto indexText = text.substr(bracketPos + 1, closePos - bracketPos - 1);
 
   if (const auto bitIndex = parseUnsignedInt(indexText); bitIndex.has_value()) {
-    return BitRegisterRef{.name = std::move(base), .bitIndex = *bitIndex};
+    return BitRegisterRef{.name = std::move(base), .bitIndex = bitIndex};
   }
   return std::nullopt;
 }

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -480,7 +480,7 @@ parseClassicConditionExpression(const std::string& condition) {
   }
 
   // Default values for the bare form (`c`, `c[k]`): implicit `!= 0`.
-  std::string operand{ normalized };
+  std::string operand{normalized};
   size_t expected = 0;
   qc::ComparisonKind kind = qc::Neq;
 
@@ -514,10 +514,10 @@ parseClassicConditionExpression(const std::string& condition) {
   }
 
   if (const auto ref = parseBitRegisterRef(operand); ref.has_value()) {
-  return ClassicCondition{.registerName = ref->name,
-                          .bitIndex = ref->bitIndex,
-                          .expectedValue = expected,
-                          .kind = kind};
+    return ClassicCondition{.registerName = ref->name,
+                            .bitIndex = ref->bitIndex,
+                            .expectedValue = expected,
+                            .kind = kind};
   }
   return std::nullopt;
 }

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -31,7 +31,6 @@
 #include <memory>
 #include <optional>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -77,33 +76,34 @@ std::optional<size_t> parseUnsignedInt(std::string_view text) {
 }
 
 /**
- * @brief A reference into a classical bit register.
+ * @brief A reference to a register, or to a single element within a register.
  *
- * `bitIndex` holds the index of a single bit within the register.
- * When it is `std::nullopt`, the reference targets the whole register
- * rather than an individual bit.
+ * `index` can hold the following values:
+ * - `std::nullopt`, when the reference targets the whole register (`c`, `q`).
+ * - the position within the register, when the reference targets a single
+ *   element (`c[k]`, `q[k]`).
  */
-struct BitRegisterRef {
+struct RegisterRef {
   std::string name;
-  std::optional<size_t> bitIndex;
+  std::optional<size_t> index;
 };
 
 /**
- * @brief Parse a classical bit register reference from the given text.
+ * @brief Parse a register reference from the given text.
  *
- * Accepts either the bare register name (`c`), which resolves to
- * `{name = "c", bitIndex = std::nullopt}` and targets the whole register,
- * or the indexed form (`c[k]`), which resolves to a single-bit reference.
+ * Accepts either the bare register name (`c`, `q`), which resolves to
+ * `{name = "c", index = std::nullopt}` and targets the whole register,
+ * or the indexed form (`c[k]`), which resolves to a single-element reference.
  * @param text The already-trimmed text to parse.
  * @return The parsed reference, or `std::nullopt` if the shape is invalid.
  */
-std::optional<BitRegisterRef> parseBitRegisterRef(const std::string& text) {
+std::optional<RegisterRef> parseRegisterRef(const std::string& text) {
   if (text.empty()) {
     return std::nullopt;
   }
   const auto bracketPos = text.find('[');
   if (bracketPos == std::string::npos) {
-    return BitRegisterRef{.name = text, .bitIndex = std::nullopt};
+    return RegisterRef{.name = text, .index = std::nullopt};
   }
   const auto closePos = text.find(']', bracketPos + 1);
   if (bracketPos == 0 || closePos == std::string::npos ||
@@ -113,8 +113,8 @@ std::optional<BitRegisterRef> parseBitRegisterRef(const std::string& text) {
   auto base = text.substr(0, bracketPos);
   const auto indexText = text.substr(bracketPos + 1, closePos - bracketPos - 1);
 
-  if (const auto bitIndex = parseUnsignedInt(indexText); bitIndex.has_value()) {
-    return BitRegisterRef{.name = std::move(base), .bitIndex = bitIndex};
+  if (const auto index = parseUnsignedInt(indexText); index.has_value()) {
+    return RegisterRef{.name = std::move(base), .index = index};
   }
   return std::nullopt;
 }
@@ -239,37 +239,20 @@ void validateTargets(const std::string& code, size_t instructionStart,
       detail += ".";
       throw makeParseError(code, instructionStart, detail);
     }
-    const auto open = target.find('[');
-    if (open == std::string::npos) {
+    const auto ref = parseRegisterRef(target);
+    if (!ref.has_value()) {
+      throw makeParseError(code, instructionStart,
+                           invalidTargetDetail(target, context), target);
+    }
+    if (!ref->index.has_value()) {
       continue;
     }
-    const auto close = target.find(']', open + 1);
-    if (open == 0 || close == std::string::npos || close != target.size() - 1) {
-      throw makeParseError(code, instructionStart,
-                           invalidTargetDetail(target, context), target);
-    }
-    const auto registerName = target.substr(0, open);
-    const auto indexText = target.substr(open + 1, close - open - 1);
-    if (!isDigits(indexText)) {
-      throw makeParseError(code, instructionStart,
-                           invalidTargetDetail(target, context), target);
-    }
-    size_t registerIndex = 0;
-    try {
-      registerIndex = std::stoul(indexText);
-    } catch (const std::invalid_argument&) {
-      throw makeParseError(code, instructionStart,
-                           invalidTargetDetail(target, context), target);
-    } catch (const std::out_of_range&) {
-      throw makeParseError(code, instructionStart,
-                           invalidTargetDetail(target, context), target);
-    }
-    if (std::ranges::find(shadowedRegisters, registerName) !=
+    if (std::ranges::find(shadowedRegisters, ref->name) !=
         shadowedRegisters.end()) {
       continue;
     }
-    const auto found = definedRegisters.find(registerName);
-    if (found == definedRegisters.end() || found->second <= registerIndex) {
+    const auto found = definedRegisters.find(ref->name);
+    if (found == definedRegisters.end() || found->second <= *ref->index) {
       throw makeParseError(code, instructionStart,
                            invalidTargetDetail(target, context), target);
     }
@@ -524,9 +507,9 @@ parseClassicConditionExpression(const std::string& condition) {
     kind = match->kind;
   }
 
-  if (const auto ref = parseBitRegisterRef(operand); ref.has_value()) {
+  if (const auto ref = parseRegisterRef(operand); ref.has_value()) {
     return ClassicCondition{.registerName = ref->name,
-                            .bitIndex = ref->bitIndex,
+                            .bitIndex = ref->index,
                             .expectedValue = expected,
                             .kind = kind};
   }

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <cstddef>
 #include <exception>
 #include <iterator>
@@ -33,6 +34,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -51,6 +53,27 @@ bool isDigits(const std::string& text) {
   }
   return std::ranges::all_of(
       text, [](unsigned char c) { return std::isdigit(c) != 0; });
+}
+
+/**
+ * @brief Parse the entire text as an unsigned integer.
+ *
+ * The text must contain only characters accepted by `std::from_chars` for the
+ * target type (digits, no leading sign, no whitespace, no trailing garbage).
+ * Anything else, including partial matches, fails.
+ * @param text The text to parse.
+ * @return The parsed value, or `std::nullopt` if parsing fails or does not
+ *         consume the whole input.
+ */
+std::optional<size_t> parseUnsignedInt(std::string_view text) {
+  size_t value = 0;
+  const char* const begin = std::to_address(text.begin());
+  const char* const end = std::to_address(text.end());
+  const auto result = std::from_chars(begin, end, value);
+  if (result.ec != std::errc{} || result.ptr != end) {
+    return std::nullopt;
+  }
+  return value;
 }
 
 /**
@@ -89,18 +112,11 @@ std::optional<BitRegisterRef> parseBitRegisterRef(const std::string& text) {
   }
   auto base = text.substr(0, bracketPos);
   const auto indexText = text.substr(bracketPos + 1, closePos - bracketPos - 1);
-  if (!isDigits(indexText)) {
-    return std::nullopt;
+
+  if (const auto bitIndex = parseUnsignedInt(indexText); bitIndex.has_value()) {
+    return BitRegisterRef{.name = std::move(base), .bitIndex = *bitIndex};
   }
-  size_t bitIndex = 0;
-  try {
-    bitIndex = std::stoull(indexText);
-  } catch (const std::invalid_argument&) {
-    return std::nullopt;
-  } catch (const std::out_of_range&) {
-    return std::nullopt;
-  }
-  return BitRegisterRef{.name = std::move(base), .bitIndex = bitIndex};
+  return std::nullopt;
 }
 
 /**
@@ -499,16 +515,11 @@ parseClassicConditionExpression(const std::string& condition) {
     if (lhs.empty() || rhs.empty()) {
       return std::nullopt;
     }
-    if (!isDigits(rhs)) {
+    const auto parsed = parseUnsignedInt(rhs);
+    if (!parsed.has_value()) {
       return std::nullopt;
     }
-    try {
-      expected = std::stoull(rhs);
-    } catch (const std::invalid_argument&) {
-      return std::nullopt;
-    } catch (const std::out_of_range&) {
-      return std::nullopt;
-    }
+    expected = *parsed;
     operand = lhs;
     kind = match->kind;
   }

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -459,11 +459,6 @@ ClassicControlledGate parseClassicControlledGate(const std::string& code) {
 
 std::optional<ClassicCondition>
 parseClassicConditionExpression(const std::string& condition) {
-  auto normalized = removeWhitespace(condition);
-  if (!normalized.empty() && normalized.front() == '(') {
-    normalized.erase(0, 1);
-  }
-
   // Operators must be scanned longest-first so that "<=" is not misread as "<".
   struct OperatorMatch {
     std::string_view text;
@@ -479,6 +474,17 @@ parseClassicConditionExpression(const std::string& condition) {
       {.text = ">", .kind = qc::Gt},
   }};
 
+  auto normalized = removeWhitespace(condition);
+  if (!normalized.empty() && normalized.front() == '(') {
+    normalized.erase(0, 1);
+  }
+
+  // Default values for the bare form (`c`, `c[k]`): implicit `!= 0`.
+  std::string operand{ normalized };
+  size_t expected = 0;
+  qc::ComparisonKind kind = qc::Neq;
+
+  // Comparator form (`c` <op> integer).
   std::optional<OperatorMatch> match;
   for (const auto& op : OPERATORS) {
     if (normalized.find(op.text) != std::string::npos) {
@@ -486,45 +492,34 @@ parseClassicConditionExpression(const std::string& condition) {
       break;
     }
   }
-  if (!match.has_value()) {
-    // Bare register (`c`) or bit (`c[k]`).
-    // Treat it as an implicit `!= 0` check so the existing evaluator handles it
-    // unchanged.
-    if (const auto ref = parseBitRegisterRef(normalized); ref.has_value()) {
-      return ClassicCondition{.registerName = ref->name,
-                              .bitIndex = ref->bitIndex,
-                              .expectedValue = 0,
-                              .kind = qc::Neq};
+  if (match.has_value()) {
+    const auto opPos = normalized.find(match->text);
+    const auto lhs = normalized.substr(0, opPos);
+    const auto rhs = normalized.substr(opPos + match->text.size());
+    if (lhs.empty() || rhs.empty()) {
+      return std::nullopt;
     }
-    return std::nullopt;
-  }
-  const auto opPos = normalized.find(match->text);
-  const auto lhs = normalized.substr(0, opPos);
-  const auto rhs = normalized.substr(opPos + match->text.size());
-  if (lhs.empty() || rhs.empty()) {
-    return std::nullopt;
-  }
-
-  if (!isDigits(rhs)) {
-    return std::nullopt;
-  }
-  size_t expected = 0;
-  try {
-    expected = std::stoull(rhs);
-  } catch (const std::invalid_argument&) {
-    return std::nullopt;
-  } catch (const std::out_of_range&) {
-    return std::nullopt;
+    if (!isDigits(rhs)) {
+      return std::nullopt;
+    }
+    try {
+      expected = std::stoull(rhs);
+    } catch (const std::invalid_argument&) {
+      return std::nullopt;
+    } catch (const std::out_of_range&) {
+      return std::nullopt;
+    }
+    operand = lhs;
+    kind = match->kind;
   }
 
-  const auto ref = parseBitRegisterRef(lhs);
-  if (!ref.has_value()) {
-    return std::nullopt;
-  }
+  if (const auto ref = parseBitRegisterRef(operand); ref.has_value()) {
   return ClassicCondition{.registerName = ref->name,
                           .bitIndex = ref->bitIndex,
                           .expectedValue = expected,
-                          .kind = match->kind};
+                          .kind = kind};
+  }
+  return std::nullopt;
 }
 
 std::optional<ClassicCondition>

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -54,6 +54,56 @@ bool isDigits(const std::string& text) {
 }
 
 /**
+ * @brief A reference into a classical bit register.
+ *
+ * `bitIndex` holds the index of a single bit within the register.
+ * When it is `std::nullopt`, the reference targets the whole register
+ * rather than an individual bit.
+ */
+struct BitRegisterRef {
+  std::string name;
+  std::optional<size_t> bitIndex;
+};
+
+/**
+ * @brief Parse a classical bit register reference from the given text.
+ *
+ * Accepts either the bare register name (`c`), which resolves to
+ * `{name = "c", bitIndex = std::nullopt}` and targets the whole register,
+ * or the indexed form (`c[k]`), which resolves to a single-bit reference.
+ * @param text The already-trimmed text to parse.
+ * @return The parsed reference, or `std::nullopt` if the shape is invalid.
+ */
+std::optional<BitRegisterRef> parseBitRegisterRef(const std::string& text) {
+  if (text.empty()) {
+    return std::nullopt;
+  }
+  const auto bracketPos = text.find('[');
+  if (bracketPos == std::string::npos) {
+    return BitRegisterRef{.name = text, .bitIndex = std::nullopt};
+  }
+  const auto closePos = text.find(']', bracketPos + 1);
+  if (bracketPos == 0 || closePos == std::string::npos ||
+      closePos != text.size() - 1) {
+    return std::nullopt;
+  }
+  auto base = text.substr(0, bracketPos);
+  const auto indexText = text.substr(bracketPos + 1, closePos - bracketPos - 1);
+  if (!isDigits(indexText)) {
+    return std::nullopt;
+  }
+  size_t bitIndex = 0;
+  try {
+    bitIndex = std::stoull(indexText);
+  } catch (const std::invalid_argument&) {
+    return std::nullopt;
+  } catch (const std::out_of_range&) {
+    return std::nullopt;
+  }
+  return BitRegisterRef{.name = std::move(base), .bitIndex = bitIndex};
+}
+
+/**
  * @brief 1-based line/column location within source text.
  */
 struct LineColumn {
@@ -458,35 +508,12 @@ parseClassicConditionExpression(const std::string& condition) {
     return std::nullopt;
   }
 
-  const auto bracketPos = lhs.find('[');
-  if (bracketPos != std::string::npos) {
-    const auto closePos = lhs.find(']', bracketPos + 1);
-    if (bracketPos == 0 || closePos == std::string::npos ||
-        closePos != lhs.size() - 1) {
-      return std::nullopt;
-    }
-    const auto base = lhs.substr(0, bracketPos);
-    const auto indexText =
-        lhs.substr(bracketPos + 1, closePos - bracketPos - 1);
-    if (!isDigits(indexText)) {
-      return std::nullopt;
-    }
-    size_t bitIndex = 0;
-    try {
-      bitIndex = std::stoull(indexText);
-    } catch (const std::invalid_argument&) {
-      return std::nullopt;
-    } catch (const std::out_of_range&) {
-      return std::nullopt;
-    }
-    return ClassicCondition{.registerName = base,
-                            .bitIndex = bitIndex,
-                            .expectedValue = expected,
-                            .kind = match->kind};
+  const auto ref = parseBitRegisterRef(lhs);
+  if (!ref.has_value()) {
+    return std::nullopt;
   }
-
-  return ClassicCondition{.registerName = lhs,
-                          .bitIndex = std::nullopt,
+  return ClassicCondition{.registerName = ref->name,
+                          .bitIndex = ref->bitIndex,
                           .expectedValue = expected,
                           .kind = match->kind};
 }

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -260,6 +260,84 @@ TEST_F(CustomCodeTest, IfElseOperationBackwardStep) {
 }
 
 /**
+ * @test Test classic-controlled operations that use a bare classical register
+ * as the condition (no explicit comparator).
+ * The measured value of `c` is 1, so `if (c)` triggers and `x q[1]` is applied.
+ */
+TEST_F(CustomCodeTest, IfElseOperationBareRegisterTrue) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c) x q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  // q[0] = 1, q[1] = 0 after the `if` flips q[1] from 1 to 0.
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Same as `IfElseOperationBareRegisterTrue` but with the measurement
+ * producing 0, so `if (c)` does not trigger.
+ */
+TEST_F(CustomCodeTest, IfElseOperationBareRegisterFalse) {
+  loadCode(2, 1,
+           "measure q[0] -> c[0];"
+           "if(c) x q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  // Both qubits stay at |0>; the `if` is skipped.
+  ASSERT_TRUE(complexEquality(amplitudes[0], 1, 0.0));
+}
+
+/**
+ * @test Same as `IfElseOperationBareRegisterTrue` but using a single-bit
+ * reference (`c[0]`) as the bare condition.
+ */
+TEST_F(CustomCodeTest, IfElseOperationBareBit) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c[0]) x q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+}
+
+/**
+ * @test Exercise the backward-execution branch for a bare-register condition.
+ * Stepping back should undo the `x q[1]` that fired on the forward pass.
+ */
+TEST_F(CustomCodeTest, IfElseOperationBareRegisterBackwardStep) {
+  loadCode(2, 1,
+           "x q[0];"
+           "cx q[0], q[1];"
+           "measure q[0] -> c[0];"
+           "if(c) x q[1];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  std::array<Complex, 4> amplitudes{};
+  Statevector sv{2, 4, amplitudes.data()};
+  state->getStateVectorFull(state, &sv);
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1, 0.0));
+
+  ASSERT_EQ(state->stepBackward(state), OK);
+  state->getStateVectorFull(state, &sv);
+  // Undoing the `if(c) x q[1]` restores q[0] = 1, q[1] = 1, i.e. index 3.
+  ASSERT_TRUE(complexEquality(amplitudes[3], 1, 0.0));
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Let the debugger evaluate classic-controlled `if` conditions written without an explicit comparator,
treating the operand as an implicit "non-zero" check.

OpenQASM 3 allows a classical register or a single bit as a boolean condition with no explicit comparator:

```
if (c) x q[0];
if (c[0]) x q[0];
```

Before this PR the debugger's parser rejected these forms (returned `nullopt`), so the classic-controlled gate failed to parse. mqt-core's `IfElseOperation` already models the shape, so only the debugger front-end needed to catch up.

### Implementation

`parseClassicConditionExpression` scans the condition text for one of the six comparators (`==`, `!=`, `<`, `<=`, `>`, `>=`). If none is found, the whole text is now treated as a bare register or bit reference (`c` or `c[k]`) and interpreted as an implicit `!= 0` check. The bare form populates `ClassicCondition` with `.kind = qc::Neq` and `.expectedValue = 0`, so the existing evaluator handles both forms with the same code path.

The structural parsing of `name` or `name[index]` lives in a shared `parseRegisterRef` helper used both by the classic-condition path and by `validateTargets` (for qubit targets in gate calls). Numeric parsing goes through a `parseUnsignedInt` helper backed by `std::from_chars`, so no exceptions are thrown and no `isDigits` pre-check is needed.

End-to-end tests in `test_custom_code.cpp` cover the satisfied case, the unsatisfied case, the single-bit form, and one backward-step case, mirroring the coverage added in PR #456.

Closes #470.

### AI assistance

Commit messages, code changes, and this PR body were drafted with Claude Opus 4.7 via Claude Code.
All content was reviewed and edited manually before submission.

Fixes #462.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content and accept full responsibility for it.