### PR TITLE
🐛 Clear classical bits in `resetSimulationState`

### DIFF
--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -190,6 +190,11 @@ void resetSimulationState(DDSimulationState* ddsim) {
       dd::makeZeroState(ddsim->qc->getNqubits(), *(ddsim->dd));
   ddsim->dd->incRef(ddsim->simulationState);
   ddsim->paused = false;
+  // Return the classical side to its initial state (all bits false),
+  // matching the quantum state rebuilt above.
+  std::ranges::for_each(
+      ddsim->variables | std::views::values,
+      [](auto& variable) { variable.value.boolValue = false; });
 }
 
 /**

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -280,6 +280,27 @@ TEST_F(CustomCodeTest, ResetGate) {
 }
 
 /**
+ * @test Test that `resetSimulation` returns the classical side to its initial
+ * state, not just the quantum state.
+ * After running a program that measures `q[0] = |1>` into `c[0]`, `c[0]` holds
+ * `true`; a subsequent `resetSimulation` must set it back to `false`.
+ */
+TEST_F(CustomCodeTest, ResetSimulationClearsClassicalBits) {
+  loadCode(1, 1,
+           "x q[0];"
+           "measure q[0] -> c[0];");
+  ASSERT_EQ(state->runSimulation(state), OK);
+
+  Variable v;
+  ASSERT_EQ(state->getClassicalVariable(state, "c[0]", &v), OK);
+  ASSERT_TRUE(classicalEquals(v, true));
+
+  ASSERT_EQ(state->resetSimulation(state), OK);
+  ASSERT_EQ(state->getClassicalVariable(state, "c[0]", &v), OK);
+  ASSERT_TRUE(classicalEquals(v, false));
+}
+
+/**
  * @test Test that parsing works correctly even if a custom gate name includes
  * the keyword `gate`.
  */


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

`resetSimulationState` in `src/backend/dd/DDSimDebug.cpp` rebuilt the quantum state on `reset` but left `ddsim->variables` (the map of classical bit values) untouched. After a first `run` followed by `reset`, reading `c[k]` returned the value from the previous run rather than the initial `false`, and the next `measure` on the same bit looked like a no-op because the bit already held the value it would receive.

This PR iterates `ddsim->variables` with `std::ranges::for_each` over `std::views::values` after the quantum state rebuild and sets each `boolValue` back to `false`, matching how the quantum side is reset. Includes an end-to-end test that runs a program, verifies `c[0]` is `true`, calls `resetSimulation`, and verifies `c[0]` is `false`.

### AI assistance

Commit messages, code changes, and this PR body were drafted with Claude Opus 4.7 via Claude Code. All content was reviewed and edited manually before submission.

Fixes #464.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content and accept full responsibility for it.
