### PR TITLE
⬆️ Raise minimum Qiskit version to 2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ email = "burgholzer@me.com"
 check = [
   "numpy>=2.1",
   "numpy>=2.3.2; python_version>='3.14'",
-  "qiskit>=1.2.4",
+  "qiskit>=2.1",
   "scipy>=1.13.1",
   "scipy>=1.15; python_version>='3.13'",
   "scipy>=1.16.2; python_version>='3.14'",
@@ -90,7 +90,7 @@ test = [
   "pytest-cov>=7.1",
   "pytest-sugar>=1.1.1",
   "pytest-xdist>=3.8",
-  "qiskit>=1.2.4",
+  "qiskit>=2.1",
   "scipy>=1.13.1",
 ]
 docs = [
@@ -99,7 +99,7 @@ docs = [
   "myst-nb>=1.4",
   "openqasm-pygments>=0.2",
   "pandas[output-formatting]>=2.1.2",
-  "qiskit[qasm3-import,visualization]>=1",
+  "qiskit[qasm3-import,visualization]>=2.1",
   "sphinx>=9",
   "sphinx-copybutton>=0.5.2",
   "sphinx-design>=0.7",
@@ -173,11 +173,6 @@ wheel.py-api = "cp315t"
 
 [tool.uv]
 required-version = ">=0.5.20"
-# symengine>=0.11,<0.14 (optional dependency of qiskit) is incompatible with Python 3.14
-override-dependencies = [
-  "symengine>=0.11,<0.14; python_version < '3.14'",
-  "symengine>=0.14.1; python_version >= '3.14'",
-]
 cache-keys = [
   { file = "pyproject.toml" },
   { git = { commit = true, tags = true } },

--- a/uv.lock
+++ b/uv.lock
@@ -19,12 +19,6 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
-[manifest]
-overrides = [
-    { name = "symengine", marker = "python_full_version < '3.14'", specifier = ">=0.11,<0.14" },
-    { name = "symengine", marker = "python_full_version >= '3.14'", specifier = ">=0.14.1" },
-]
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -1510,10 +1504,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nanobind-backend", specifier = ">=1.0" },
+    { name = "nanobind-backend", specifier = ">=1" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'check'", specifier = ">=2.3.2" },
     { name = "numpy", marker = "extra == 'check'", specifier = ">=2.1" },
-    { name = "qiskit", marker = "extra == 'check'", specifier = ">=1.2.4" },
+    { name = "qiskit", marker = "extra == 'check'", specifier = ">=2.1" },
     { name = "scipy", marker = "python_full_version >= '3.13' and extra == 'check'", specifier = ">=1.15" },
     { name = "scipy", marker = "python_full_version >= '3.14' and extra == 'check'", specifier = ">=1.16.2" },
     { name = "scipy", marker = "extra == 'check'", specifier = ">=1.13.1" },
@@ -1525,7 +1519,7 @@ build = [
     { name = "cmake", specifier = ">=4.4.1" },
     { name = "nanobind", specifier = "~=3.0.1" },
     { name = "scikit-build-core", specifier = ">=1.0.3" },
-    { name = "vcs-versioning", specifier = ">=2.3.0" },
+    { name = "vcs-versioning", specifier = ">=2.3" },
 ]
 dev = [
     { name = "cmake", specifier = ">=4.4.1" },
@@ -1534,37 +1528,37 @@ dev = [
     { name = "numpy", specifier = ">=2.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", specifier = ">=1.2.4" },
+    { name = "pytest-xdist", specifier = ">=3.8" },
+    { name = "qiskit", specifier = ">=2.1" },
     { name = "scikit-build-core", specifier = ">=1.0.3" },
     { name = "scipy", specifier = ">=1.13.1" },
-    { name = "vcs-versioning", specifier = ">=2.3.0" },
+    { name = "vcs-versioning", specifier = ">=2.3" },
 ]
 docs = [
-    { name = "breathe", specifier = ">=4.36.0" },
+    { name = "breathe", specifier = ">=4.36" },
     { name = "furo", specifier = ">=2025.12.19" },
-    { name = "myst-nb", specifier = ">=1.4.0" },
-    { name = "openqasm-pygments", specifier = ">=0.2.0" },
+    { name = "myst-nb", specifier = ">=1.4" },
+    { name = "openqasm-pygments", specifier = ">=0.2" },
     { name = "pandas", extras = ["output-formatting"], specifier = ">=2.1.2" },
-    { name = "qiskit", extras = ["qasm3-import", "visualization"], specifier = ">=1.0.0" },
-    { name = "sphinx", specifier = ">=9.0" },
+    { name = "qiskit", extras = ["qasm3-import", "visualization"], specifier = ">=2.1" },
+    { name = "sphinx", specifier = ">=9" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
-    { name = "sphinx-design", specifier = ">=0.7.0" },
+    { name = "sphinx-design", specifier = ">=0.7" },
     { name = "sphinx-hoverxref", specifier = ">=1.4.2" },
-    { name = "sphinx-llm", specifier = ">=1.0.0" },
-    { name = "sphinxcontrib-bibtex", specifier = ">=2.7.0" },
-    { name = "sphinxext-opengraph", specifier = ">=0.10.0" },
+    { name = "sphinx-llm", specifier = ">=1" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.7" },
+    { name = "sphinxext-opengraph", specifier = ">=0.10" },
 ]
 test = [
     { name = "numpy", specifier = ">=2.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", specifier = ">=1.2.4" },
+    { name = "pytest-xdist", specifier = ">=3.8" },
+    { name = "qiskit", specifier = ">=2.1" },
     { name = "scipy", specifier = ">=1.13.1" },
 ]
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Raise the minimum Qiskit version to 2.1 for runtime checks, tests, and documentation. Qiskit 2.1 no longer requires SymEngine, so the compatibility overrides can be removed.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/debugger/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
